### PR TITLE
Add ChatMessage component and content encoding/decoding

### DIFF
--- a/src/LetsTalk.WebApp/src/lib/components/ChatMessage.svelte
+++ b/src/LetsTalk.WebApp/src/lib/components/ChatMessage.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import { decodeContent } from '$lib/encoding';
+	import type { MessageEvent } from '$lib/events';
+
+	let { message, alignment = 'start' }: { message: MessageEvent; alignment: 'start' | 'end' } =
+		$props();
+
+	function formatTimestamp(timestamp: string): string {
+		return new Date(message.timestamp).toLocaleString();
+	}
+
+	function formatTime(timestamp: string): string {
+		return new Date(timestamp).toLocaleTimeString([], {
+			hour: '2-digit',
+			minute: '2-digit'
+		});
+	}
+
+	const defaultAvatarUrl = `https://ui-avatars.com/api/?name=${message.author.userName.replace(/[\s\.\_]/g, '+')}&background=random&rounded=true&size=256`;
+</script>
+
+<div class="chat chat-{alignment}">
+	<div class="chat-image avatar">
+		<div class="w-10 rounded-full">
+			<img
+				alt="{message.author.userName} Avatar"
+				src={message.author.avatarUrl ?? defaultAvatarUrl}
+			/>
+		</div>
+	</div>
+	<div class="chat-header">
+		{message.author.userName}
+		<div class="tooltip" data-tip={formatTimestamp(message.timestamp)}>
+			<time class="text-xs opacity-50">{formatTime(message.timestamp)}</time>
+		</div>
+	</div>
+	<div class="chat-bubble">{decodeContent(message.contentType, message.content)}</div>
+	<!-- <div class="chat-footer opacity-50">Delivered</div> -->
+</div>

--- a/src/LetsTalk.WebApp/src/lib/encoding.ts
+++ b/src/LetsTalk.WebApp/src/lib/encoding.ts
@@ -1,0 +1,25 @@
+type EncodeMap = {
+    'text/plain': string;
+}
+
+const textEncoder = new TextEncoder();
+
+// TODO: Replace atob and btoa with Buffer.from and Buffer.toString('base64').
+
+export function encodeContent<T extends keyof EncodeMap>(contentType: T, content: string): EncodeMap[T] {
+    switch (contentType) {
+        case 'text/plain':
+            return btoa(String.fromCharCode(...textEncoder.encode(content)));
+        default:
+            throw new Error(`Unsupported content type: ${contentType}`);
+    }
+}
+
+export function decodeContent<T extends keyof EncodeMap>(contentType: T, content: EncodeMap[T]): string {
+    switch (contentType) {
+        case 'text/plain':
+            return atob(content);
+        default:
+            throw new Error(`Unsupported content type: ${contentType}`);
+    }
+}


### PR DESCRIPTION
- Updated `+page.svelte` to import `ChatMessage`, `decodeContent`, `encodeContent`, and `mount`.
- Modified `HubClient` event handlers to use `ChatMessage` and `decodeContent`.
- Added a dummy message event in `+page.svelte` for testing.
- Updated form submission handler to use `encodeContent` before sending messages.
- Created `encoding.ts` for content encoding/decoding with `EncodeMap`, `TextEncoder`, `encodeContent`, and `decodeContent`.
- Created `ChatMessage.svelte` to display chat messages with formatting and details.